### PR TITLE
Exclude the /_ah/.* URLs from HTTPS enforcement

### DIFF
--- a/scaffold/settings_live.py
+++ b/scaffold/settings_live.py
@@ -8,5 +8,11 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_SSL_REDIRECT = True
 
+
+SECURE_REDIRECT_EXEMPT = [
+    # djangosecure compares these to request.path.lstrip("/"), hence the lack of preceding /
+    r"^_ah/"
+]
+
 DEBUG = False
 TEMPLATE_DEBUG = False


### PR DESCRIPTION
GAE doesn't seem to use HTTPS internally, so without this all `/_ah/` URLs return a 301.

Note that it's still ok to have `secure: always` in app.yaml, as GAE seems to ignore this for internal URLs.