### PR TITLE
Updated install_deps to handle deprecated SDK versions

### DIFF
--- a/install_deps
+++ b/install_deps
@@ -18,7 +18,15 @@ REQUIREMENTS_FILE = os.path.join(PROJECT_DIR, "requirements.txt")
 TARGET_DIR = os.path.join(PROJECT_DIR, "sitepackages")
 
 APPENGINE_TARGET_DIR = os.path.join(TARGET_DIR, "google_appengine")
-APPENGINE_SDK_URL = "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.15.zip"
+
+APPENGINE_SDK_VERSION = "1.9.17"
+APPENGINE_SDK_FILENAME = "google_appengine_%s.zip" % APPENGINE_SDK_VERSION
+
+# Google move versions from 'featured' to 'deprecated' when they bring
+# out new releases
+FEATURED_SDK_REPO = "https://storage.googleapis.com/appengine-sdks/featured/"
+DEPRECATED_SDK_REPO = "https://storage.googleapis.com/appengine-sdks/deprecated/%s/" % APPENGINE_SDK_VERSION.replace('.', '')
+
 
 if __name__ == "__main__":
     #Make sure the user has everything they need
@@ -33,8 +41,17 @@ if __name__ == "__main__":
     if not os.path.exists(APPENGINE_TARGET_DIR):
         print('Downloading the AppEngine SDK...')
 
-        url = urlopen(APPENGINE_SDK_URL)
-        zipfile = ZipFile(StringIO(url.read()))
+        #First try and get it from the 'featured' folder
+        sdk_file = urlopen(FEATURED_SDK_REPO + APPENGINE_SDK_FILENAME)
+        if sdk_file.getcode() == 404:
+            #Failing that, 'deprecated'
+            sdk_file = urlopen(DEPRECATED_SDK_REPO + APPENGINE_SDK_FILENAME)
+
+        #Handle other errors
+        if sdk_file.getcode() >= 299:
+            raise Exception('App Engine SDK could not be found. {} returned code {}.'.format(sdk_file.geturl(), sdk_file.getcode()))
+
+        zipfile = ZipFile(StringIO(sdk_file.read()))
         zipfile.extractall(TARGET_DIR)
 
         #Make sure the dev_appserver and appcfg are executable


### PR DESCRIPTION
I got this fairly unhelpful error when I tried to run `./install_deps` in a fresh clone of this repo:

```
$ ./install_deps
Creating `sitepackages` directory for dependencies...
Downloading the AppEngine SDK...
Traceback (most recent call last):
  File "./install_deps", line 37, in <module>
    zipfile = ZipFile(StringIO(url.read()))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/zipfile.py", line 766, in __init__
    self._RealGetContents()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/zipfile.py", line 807, in _RealGetContents
    raise BadZipfile, "File is not a zip file"
zipfile.BadZipfile: File is not a zip file
```

Turns out it was just because the SDK version it tries to use (1.9.15) is slightly out of date, so Google have moved it to their 'deprecated' folder.

This update makes `./install_deps` find the named version in either 'featured' or 'deprecated'. I also updated the version it uses to 1.9.17 (latest at time of writing).
