### PR TITLE
Disable Django's XFrameOptionsMiddleware which is superseded by the one ...

### DIFF
--- a/scaffold/settings.py
+++ b/scaffold/settings.py
@@ -51,7 +51,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'djangae.contrib.gauth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'csp.middleware.CSPMiddleware',
     'session_csrf.CsrfMiddleware',
     'djangosecure.middleware.SecurityMiddleware',


### PR DESCRIPTION
...supplied by django-secure. Fixes #36