### PR TITLE
Suggest using Python 2.7.8 when running the project locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To get started:
  - Clone this repo (don't forget to change the origin to your own repo!)
  - Run `./install_deps` (this will pip install requirements, and download the App Engine SDK)
  - `python manage.py checksecure --settings=scaffold.settings_live`
- - `python manage.py runserver`
+ - `python manage.py runserver` (preferably use Python 2.7.8, as the App Engine SDK throws an exception when using Python 2.7.9)
 
 The install_deps helper script will install dependencies into a 'sitepackages' folder which is added to the path. Each time you run it your
 sitepackages will be wiped out and reinstalled with pip. The SDK will only be downloaded the first time (as it's a large download).


### PR DESCRIPTION
When running the server locally, there is a `TypeError: do_open() got an unexpected keyword argument 'context'`. This is a GAE issue discussed [here](https://code.google.com/p/googleappengine/issues/detail?id=11537), but still worth mentioning to avoid confusion when using latest stable Python 2 version.