### PR TITLE
Removing 'unsafe-inline' from CSP_STYLE_SRC when in DEBUG mode

### DIFF
--- a/scaffold/settings.py
+++ b/scaffold/settings.py
@@ -109,9 +109,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
-if DEBUG:
-    CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
-
 # sensible default CPS settings, feel free to modify them
 CSP_DEFAULT_SRC = ("'self'", "*.gstatic.com")
 CSP_STYLE_SRC = ("'self'", "fonts.googleapis.com", "*.gstatic.com")


### PR DESCRIPTION
because no one knows why it's there.  See #42.