### PR TITLE
Changing gauth installed location - up to date

### DIFF
--- a/scaffold/settings.py
+++ b/scaffold/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = (
     'djangosecure',
     'csp',
     'cspreports',
-    'djangae.contrib.gauth',
+    'djangae.contrib.gauth.datastore',
     'djangae.contrib.security',
 )
 


### PR DESCRIPTION
Changing INSTALLED_APPS:
	djangae.contrib.gauth
	to
	djangae.contrib.gauth.datastore

In line with the isntructions in
djangae installation docs