### PR TITLE
Commenting out 'djangae.contrib.uniquetool' from INSTALLED_APPS.

### DIFF
--- a/scaffold/settings.py
+++ b/scaffold/settings.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = (
     'cspreports',
     'djangae.contrib.gauth.datastore',
     'djangae.contrib.security',
-    'djangae.contrib.uniquetool',
+    # 'djangae.contrib.uniquetool',
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
It's not normally needed, and it creates a dependency on the mapreduce library (which is commented out in requirements.txt).