### PR TITLE
Skip .git when deploying to App Engine

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -32,4 +32,5 @@ skip_files:
     - requirements.txt
     - sitepackages/google_appengine*
     - \.storage.*
+    - \.git
     - (.*)\.pyc


### PR DESCRIPTION
This can cause pretty annoyance given that .git can quite quickly contain several thousand files. 