### PR TITLE
Adding /_ah/internalupload to the URLs which have `login:admin`

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,7 +6,7 @@ threadsafe: true
 
 handlers:
 
-- url: /_ah/(mapreduce|queue|warmup).*
+- url: /_ah/(mapreduce|queue|warmup|internalupload).*
   script: scaffold.wsgi.application
   login: admin
   secure: always


### PR DESCRIPTION
so that it can't be accessed externally.