### PR TITLE
Prevent remote shell error

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -25,6 +25,9 @@ handlers:
   script: scaffold.wsgi.application
   secure: always
 
+builtins:
+- remote_api: on
+
 skip_files:
     - manage.py
     - README.md


### PR DESCRIPTION
In order to use remote shell, follow the page https://djangae.readthedocs.org/en/latest/sandbox/ , but caused an error. Because of lacking remote_api definition in app.yaml