### PR TITLE
Added shebangline for bash

### DIFF
--- a/rename_scaffold_app
+++ b/rename_scaffold_app
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$#" -ne 1 ]; then
     echo "Please supply a single argument of the new app name"
     exit 1


### PR DESCRIPTION
Mark this script to be executed using bash. Users of incompatible shells will see an error otherwise.

Like with fish in my case:
Failed to execute process './rename_scaffold_app'. Reason:
exec: Exec format error
The file './rename_scaffold_app' is marked as an executable but could not be run by the operating system.