### PR TITLE
Temporarily change requirements to install Django 1.8.x instead of 1.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/potatolondon/djangae.git#egg=djangae
-django>=1.8,<1.10
+django>=1.8,<1.9
 django-secure
 django-csp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports


### PR DESCRIPTION
Running scaffold as per README instructions right now fails. This is because django-secure is not supporting Django 1.9, so we need to migrate to native Django security features. Revert that commit when #80 is merged.