### PR TITLE
Make the scaffold rename script replace dash with underscore.

### DIFF
--- a/rename_scaffold_app.sh
+++ b/rename_scaffold_app.sh
@@ -4,7 +4,10 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-perl -i -pe "s/scaffold/$1/g;" app.yaml manage.py
-perl -i -pe "s/scaffold/$1/g;" scaffold/*.py
+# Make a Python-friendly version of the project name.
+PY_PROJECT_NAME=$(echo $1 | tr '-' '_')
 
-mv ./scaffold "$1"
+perl -i -pe "s/scaffold/$1/g;" app.yaml
+perl -i -pe "s/scaffold/$PY_PROJECT_NAME/g;" manage.py scaffold/*.py
+
+mv ./scaffold "$PY_PROJECT_NAME"


### PR DESCRIPTION
Hi,

This changes makes the rename script handle dashes in the application name.

With this change, if you rename your app to "foo-bar" then in app.yaml it will have "application: foo-bar", but everywhere else will be renamed to "foo_bar".

This addresses the first point in #87 .

I haven't checked if the translation syntax works in shells other than Bash.

Dave