### PR TITLE
Switch to Django 1.8+ syntax for `urlpatterns`

### DIFF
--- a/scaffold/urls.py
+++ b/scaffold/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 import session_csrf
 session_csrf.monkeypatch()
@@ -6,7 +6,7 @@ session_csrf.monkeypatch()
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = (
     # Examples:
     # url(r'^$', 'scaffold.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),


### PR DESCRIPTION
`django.conf.urls.patterns()` is deprecated: https://docs.djangoproject.com/en/1.9/releases/1.8/#django-conf-urls-patterns
