### PR TITLE
Use appengine to serve static files in production, Django in development

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -15,8 +15,8 @@ handlers:
   script: {{ project_name }}.wsgi.application
   secure: always
 
-- url: /static/admin/
-  static_dir: sitepackages/django/contrib/admin/static/admin/
+- url: /static
+  static_dir: static/
   secure: always
 
 # Set Django admin to be login:admin as well as Django's is_staff restriction

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -114,7 +114,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = '/static/'
+# Using a route that is not caught by appengines routing in app.yaml
+STATIC_URL = '/static-dev/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # sensible default CSP settings, feel free to modify them
 CSP_DEFAULT_SRC = ("'self'", "*.gstatic.com")

--- a/project_name/settings_live.py
+++ b/project_name/settings_live.py
@@ -8,6 +8,10 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_SSL_REDIRECT = True
 
+# Using a route that is caught by appengines app.yaml, be sure to collectstatic before
+# doing a deploy
+STATIC_URL = '/static/'
+
 SECURE_REDIRECT_EXEMPT = [
     # App Engine doesn't use HTTPS internally, so the /_ah/.* URLs need to be exempt.
     # Django compares these to request.path.lstrip("/"), hence the lack of preceding /

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,4 +1,7 @@
+from django.conf import settings
 from django.conf.urls import include, url
+from django.conf.urls.static import static
+from django.contrib.staticfiles.views import serve
 
 import session_csrf
 session_csrf.monkeypatch()
@@ -19,3 +22,6 @@ urlpatterns = (
 
     url(r'^auth/', include('djangae.contrib.gauth.urls')),
 )
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, view=serve, show_indexes=True)


### PR DESCRIPTION
Catching production routes to static using app.yaml and `/static/` in Django, and in development, falling onto Django's static serving

Fixes #100 