### PR TITLE
Change requirement for Django so that we install 1.10.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 djangae==0.9.6
-django>=1.8,<1.10
+django>=1.8,<=1.10
 git+https://github.com/mozilla/django-csp.git#egg=djangocsp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports
 django-session-csrf


### PR DESCRIPTION
There's a small argument for installing 1.8 because it has LTS, but 1.11 (which also has LTS) is out soon, so we should go for the latest version.  And we were installing 1.9, which made no sense at all.