### PR TITLE
Better skip_files in app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -30,11 +30,15 @@ handlers:
   secure: always
 
 skip_files:
-    - manage.py
-    - README.md
-    - install_deps
-    - requirements.txt
-    - sitepackages/dev*
-    - \.storage.*
-    - \.git
-    - (.*)\.pyc
+  - manage\.py
+  - README\.md
+  - install_deps
+  - requirements\.txt
+  - sitepackages/dev.*
+
+  # Defaults.
+  - ^(.*/)?#.*#$
+  - ^(.*/)?.*~$
+  - ^(.*/)?.*\.py[co]$
+  - ^(.*/)?.*/RCS/.*$
+  - ^(.*/)?\..*$

--- a/app.yaml
+++ b/app.yaml
@@ -30,11 +30,12 @@ handlers:
   secure: always
 
 skip_files:
-  - manage\.py
-  - README\.md
-  - install_deps
-  - requirements\.txt
-  - sitepackages/dev.*
+  - ^manage\.py$
+  - ^README\.md$
+  - ^install_deps$
+  - ^requirements/.*\.txt$
+  - ^sitepackages/dev.*
+  - ^.*\.(egg|dist)-info/.*$
 
   # Defaults.
   - ^(.*/)?#.*#$


### PR DESCRIPTION
Hi,

These changes are for the skip_files key in app.yaml.

The default skip_files is actually pretty useful, I think it would be good to keep them in new projects, and build from there.

https://cloud.google.com/appengine/docs/standard/python/config/appref#skip_files

The interesting thing is the default patterns for skip_files ignore "hidden" files and directories (things beginning with a full stop), so we don't need to have additional patterns for ".git" and ".storage".

The other changes in the list of patterns is to make them a bit stricter, closer to what was intended. The patterns are regular expressions, not shell globs, so "sitepackages/dev*" works but only because it matches a path like "sitepackages/de" followed by zero or more "v" characters.

I've also added a pattern to skip "\*.dist-info" and "\*.egg-info" directories that are created by pip / setuptools / distutils.

David B.
