### PR TITLE
Require certificate validation for TLS/SSL

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -29,6 +29,9 @@ handlers:
   script: {{ project_name }}.wsgi.application
   secure: always
 
+env_variables:
+  PYTHONHTTPSVERIFY: 1
+
 skip_files:
   - ^manage\.py$
   - ^README\.md$


### PR DESCRIPTION
The Google App Engine runtime maintains backwards compatibility by not enforcing certificate validation checks for SSL/TLS for HTTPS requests (and others) despite this being the default behaviour in recent versions of Python. New applications should be able to require certificate validation without introducing any issues and thus improve transport layer security.

Using OpenSSL
https://cloud.google.com/appengine/docs/standard/python/sockets/ssl_support

PEP 493 -- HTTPS verification migration tools for Python 2.7
https://www.python.org/dev/peps/pep-0493/