### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a barebones Django project template configured for use on App Engine usi
 
 To get started:
 
-- Install any supported Django version (`$ pip install Django==1.9`)
+- Install any supported Django version (`$ pip install Django==1.11`)
 - Run this command replacing `projectname` with your desired project name:
 
 ```

--- a/install_deps
+++ b/install_deps
@@ -25,7 +25,7 @@ PROD_TARGET_DIR = os.path.join(TARGET_DIR, "prod")
 # we don't need to upload the SDK so it lives in the dev sitepackages directory
 APPENGINE_TARGET_DIR = os.path.join(DEV_TARGET_DIR, "google_appengine")
 
-APPENGINE_SDK_VERSION = "1.9.54"
+APPENGINE_SDK_VERSION = "1.9.57"
 APPENGINE_SDK_FILENAME = "google_appengine_{}.zip".format(APPENGINE_SDK_VERSION)
 
 # Google move versions from 'featured' to 'deprecated' when they bring

--- a/install_deps
+++ b/install_deps
@@ -25,7 +25,7 @@ PROD_TARGET_DIR = os.path.join(TARGET_DIR, "prod")
 # we don't need to upload the SDK so it lives in the dev sitepackages directory
 APPENGINE_TARGET_DIR = os.path.join(DEV_TARGET_DIR, "google_appengine")
 
-APPENGINE_SDK_VERSION = "1.9.40"
+APPENGINE_SDK_VERSION = "1.9.54"
 APPENGINE_SDK_FILENAME = "google_appengine_{}.zip".format(APPENGINE_SDK_VERSION)
 
 # Google move versions from 'featured' to 'deprecated' when they bring

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = (
     # 'djangae.contrib.uniquetool',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'djangae.contrib.security.middleware.AppEngineSecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -63,11 +63,11 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 "django.contrib.auth.context_processors.auth",
-                "django.core.context_processors.debug",
-                "django.core.context_processors.i18n",
-                "django.core.context_processors.media",
-                "django.core.context_processors.static",
-                "django.core.context_processors.tz",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "session_csrf.context_processor"
             ],

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-git+https://github.com/potatolondon/djangae.git#egg=djangae
+https://github.com/potatolondon/djangae/archive/e5a86b77140e2ce0fbe464eb2afd18fe3d977a5e.zip
 django>=1.11,<2.0
 git+https://github.com/mozilla/django-csp.git#egg=djangocsp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 djangae==0.9.6
-django>=1.8,<1.10
+django>=1.11,<2.0
 git+https://github.com/mozilla/django-csp.git#egg=djangocsp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports
 django-session-csrf

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-djangae==0.9.6
+git+https://github.com/potatolondon/djangae.git#egg=djangae
 django>=1.11,<2.0
 git+https://github.com/mozilla/django-csp.git#egg=djangocsp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports


### PR DESCRIPTION
This updates django to the LTS 1.11, djangae to head and the SDK to 1.9.54 (newest compatible with Djangae AFAIK). 

There are a number of now outdated PRs this would superseed (e.g #109, #117 and #111)

It would also unblock #112 