### PR TITLE
Enclose egg parameters in quotes

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,14 +1,14 @@
 https://github.com/potatolondon/djangae/archive/e5a86b77140e2ce0fbe464eb2afd18fe3d977a5e.zip
 django>=1.11,<2.0
-git+https://github.com/mozilla/django-csp.git#egg=djangocsp
-git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports
+git+https://github.com/mozilla/django-csp.git#"egg=djangocsp"
+git+https://github.com/adamalton/django-csp-reports.git#"egg=cspreports"
 django-session-csrf
 six
 
 # Uncomment these to use mapreduce or djangae.contrib.uniquetool (which uses mapreduce)
 # These are forks of Google's libraries, which contain various fixes and patches
 #git+https://github.com/potatolondon/appengine-pipelines.git
-#git+https://github.com/potatolondon/potato-mapreduce.git#egg=mapreduce
+#git+https://github.com/potatolondon/potato-mapreduce.git#"egg=mapreduce"
 
 # Uncomment this if you want to use djangae.fields.ComputedCollationField
 # pyuca==1.1.2


### PR DESCRIPTION
./install_deps will drop errors without this fix:
"No such file or directory: '/private/var/folder..."

Ref: https://stackoverflow.com/questions/40731224/how-to-install-a-package-with-pip-from-git-if-it-has-multiple-subdirectories/40746551

This PR fixed the problem for me.
Mac 10.14.1, Homebrew 1.8.4, Python 2.7.15