### PR TITLE
Update prod.txt with stable 0.9.11

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-https://github.com/potatolondon/djangae/archive/e5a86b77140e2ce0fbe464eb2afd18fe3d977a5e.zip
+https://github.com/potatolondon/djangae/archive/v0.9.11.zip
 django>=1.11.19,<2.0
 git+https://github.com/mozilla/django-csp.git#"egg=djangocsp"
 git+https://github.com/adamalton/django-csp-reports.git#"egg=cspreports"


### PR DESCRIPTION
As far as I can tell, this was previously pointing to 0.9.11-alpha, presuming it wasn't intentional